### PR TITLE
Allow any react 0.14.x version in peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "react-script-loader": "0.0.1"
   },
   "peerDependencies": {
-    "react": "0.14.0",
-    "react-dom": "0.14.0"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "babel-cli": "6.5.x",


### PR DESCRIPTION
This solves the following Webpack warnings when using `react` and `react-dom`'s more recent minor versions:

```
myproj@1.0.0
├── UNMET PEER DEPENDENCY react@0.14.7
├── UNMET PEER DEPENDENCY react-dom@0.14.7
└── react-plaid-link@0.1.0 

npm WARN react-plaid-link@0.1.0 requires a peer of react@0.14.0 but none was installed.
npm WARN react-plaid-link@0.1.0 requires a peer of react-dom@0.14.0 but none was installed.
```