### PR TITLE
fix a bug when unmounting component

### DIFF
--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -89,7 +89,7 @@ const PlaidLink = React.createClass({
     console.error('There was an issue loading the link-initialize.js script');
   },
   onScriptLoaded: function() {
-    this.linkHandler = Plaid.create({
+    window.linkHandler = Plaid.create({
       clientName: this.props.clientName,
       env: this.props.env,
       key: this.props.publicKey,
@@ -111,10 +111,8 @@ const PlaidLink = React.createClass({
   },
   handleOnClick: function() {
     var institution = this.props.institution || null;
-    if (this.state.linkLoaded) {
+    if (window.linkHandler) {
       this.linkHandler.open(institution);
-    } else {
-      // consider a better way to wait for link to load...
     }
   },
   render: function() {


### PR DESCRIPTION
### Problem

After the component mounts the first time, the plaid script and iframe is injected into the DOM. This does not happen the second time the component mounts, but the component does not check the DOM for the existence of the Plaid object. Therefore `this.state.linkLoaded` remains false the component remounts. 

### Solution

Set `linkHandler` inside the global `window` object. And instead of checking `this.state` for whether or not the link is ready, simply check that `window.linkHandler` exists. 