### PR TITLE
fix: undefined method

### DIFF
--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -112,7 +112,7 @@ const PlaidLink = React.createClass({
   handleOnClick: function() {
     var institution = this.props.institution || null;
     if (window.linkHandler) {
-      this.linkHandler.open(institution);
+      window.linkHandler.open(institution);
     }
   },
   render: function() {


### PR DESCRIPTION
This fixes the error:

```
Uncaught TypeError: Cannot read property 'open' of undefined
    at Constructor.handleOnClick (eval at evalScript (http://localhost:3000/_next/next-dev.bundle.js:35040:4), <anonymous>:18030:24)
```