### PR TITLE
Removing longtail, since it is now deprecated in Plaid Link

### DIFF
--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -8,7 +8,6 @@ const PlaidLink = React.createClass({
   getDefaultProps: function() {
     return {
       institution: null,
-      longtail: false,
       selectAccount: false,
       buttonText: 'Open Link',
       style: {
@@ -30,10 +29,6 @@ const PlaidLink = React.createClass({
 
     // Open link to a specific institution, for a more custom solution
     institution: React.PropTypes.string,
-
-    // Set to true to launch Link with longtail institution support enabled.
-    // Longtail institutions are only available with the Connect product.
-    longtail: React.PropTypes.bool,
 
     // The public_key associated with your account; available from
     // the Plaid dashboard (https://dashboard.plaid.com)
@@ -93,7 +88,6 @@ const PlaidLink = React.createClass({
       clientName: this.props.clientName,
       env: this.props.env,
       key: this.props.publicKey,
-      longtail: this.props.longtail,
       onExit: this.props.onExit,
       onLoad: this.handleLinkOnLoad,
       onSuccess: this.props.onSuccess,


### PR DESCRIPTION
Hi, this is my first attempt to contribute to this repo. Please let me know if there is anything I need to do differently in the process. Hopefully, this proposed change is self explanatory. You may have noticed the recent console warning that longtail is deprecated for plaid link. It looks like it is no longer needed, so we should take it out of here as well.