### PR TITLE
Call this.props.onClick() from handleOnClick

### DIFF
--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -111,6 +111,7 @@ const PlaidLink = React.createClass({
     this.setState({linkLoaded: true});
   },
   handleOnClick: function() {
+    this.props.onClick && this.props.onClick();
     var institution = this.props.institution || null;
     if (window.linkHandler) {
       window.linkHandler.open(institution);


### PR DESCRIPTION
This adds calling `this.props.onClick()` from the onClick handler so as to flexibly prevent form submissions or provide functionality as the Plaid window is opened.