### PR TITLE
Update PlaidLink.js to ES6 format

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "react"],
+  "plugins": ["transform-class-properties"]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,8 @@ const WARNING = 1;
 const ERROR = 2;
 
 module.exports = {
+  parser: "babel-eslint",
+
   parserOptions: {
     'ecmaVersion': 6,
     'ecmaFeatures': {

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ start:
 
 .PHONY: test
 test:
-	@$(MOCHA) -- test/PlaidLink.spec.js
+	@$(MOCHA) -- test/components/PlaidLink.spec.js
 
 
 .PHONY: release-major release-minor release-patch

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/pbernasconi/react-plaid-link",
   "dependencies": {
-    "react-script-loader": "0.0.1"
+    "react-load-script": "0.0.6"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-core": "6.11.x",
     "babel-eslint": "4.1.x",
     "babel-loader": "6.2.x",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-es2015": "6.5.x",
     "babel-preset-react": "6.5.x",
     "babel-preset-stage-0": "6.5.x",

--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -1,7 +1,6 @@
-import { Component } from 'react'
-//import Script from "react-load-script";
-const React = require('react')
-const PropTypes = require('prop-types')
+import React, { Component } from 'react';
+import Script from "react-load-script";
+import PropTypes from 'prop-types';
 
 class PlaidLink extends Component {
   constructor(props) {
@@ -13,83 +12,12 @@ class PlaidLink extends Component {
     };
   };
 
-  static defaultProps = {
-    institution: null,
-    selectAccount: false,
-    buttonText: 'Open Link',
-    style: {
-      padding: '6px 4px',
-      outline: 'none',
-      background: '#FFFFFF',
-      border: '2px solid #F1F1F1',
-      borderRadius: '4px',
-    },
-  };
-
-  static propTypes = {
-    // Displayed once a user has successfully linked their account
-    clientName: PropTypes.string.isRequired,
-
-    // The Plaid API environment on which to create user accounts.
-    // For development and testing, use tartan. For production, use production
-    env: PropTypes.oneOf(['tartan', 'sandbox', 'development', 'production']).isRequired,
-
-    // Open link to a specific institution, for a more custom solution
-    institution: PropTypes.string,
-
-    // The public_key associated with your account; available from
-    // the Plaid dashboard (https://dashboard.plaid.com)
-    publicKey: PropTypes.string.isRequired,
-
-    // The Plaid products you wish to use, an array containing some of connect,
-    // auth, identity, income, transactions
-    product: PropTypes.arrayOf(PropTypes.oneOf(['connect', 'auth', 'identity', 'income', 'transactions'])).isRequired,
-
-    // Specify an existing user's public token to launch Link in update mode.
-    // This will cause Link to open directly to the authentication step for
-    // that user's institution.
-    token: PropTypes.string,
-
-    // Set to true to launch Link with the 'Select Account' pane enabled.
-    // Allows users to select an individual account once they've authenticated
-    selectAccount: PropTypes.bool,
-
-    // Specify a webhook to associate with a user.
-    webhook: PropTypes.string,
-
-    // A function that is called when a user has successfully onboarded their
-    // account. The function should expect two arguments, the public_key and a
-    // metadata object
-    onSuccess: PropTypes.func.isRequired,
-
-    // A function that is called when a user has specifically exited Link flow
-    onExit: PropTypes.func,
-
-    // A function that is called when the Link module has finished loading.
-    // Calls to plaidLinkHandler.open() prior to the onLoad callback will be
-    // delayed until the module is fully loaded.
-    onLoad: PropTypes.func,
-
-    // Text to display in the button
-    buttonText: PropTypes.string,
-
-    // Button Styles as an Object
-    style: PropTypes.object,
-
-    // Button Class names as a String
-    className: PropTypes.string,
-
-    // ApiVersion flag to use new version of Plaid API
-    apiVersion: PropTypes.string
-  };
-
-
   onScriptError = () => {
     console.error('There was an issue loading the link-initialize.js script');
   };
 
   onScriptLoaded = () => {
-    window.linkHandler = Plaid.create({
+    window.linkHandler = window.Plaid.create({
       clientName: this.props.clientName,
       env: this.props.env,
       key: this.props.publicKey,
@@ -125,18 +53,93 @@ class PlaidLink extends Component {
     }
   }
 
-  render: function() {
+  render() {
     return (
-      <button
-        onClick={this.handleOnClick}
-        disabled={this.state.disabledButton}
-        style={this.props.style}
-        className={this.props.className}
-      >
-        <span>{this.props.buttonText}</span>
-      </button>
+      <div>
+        <button
+          onClick={this.handleOnClick}
+          disabled={this.state.disabledButton}
+          style={this.props.style}
+          className={this.props.className}>
+          <span>{this.props.buttonText}</span>
+        </button>
+        <Script
+          url={this.state.initializeURL}
+          onError={this.onScriptError}
+          onLoad={this.onScriptLoaded} />
+      </div>
     );
   }
+};
+
+PlaidLink.defaultProps = {
+  institution: null,
+  selectAccount: false,
+  buttonText: 'Open Link',
+  style: {
+    padding: '6px 4px',
+    outline: 'none',
+    background: '#FFFFFF',
+    border: '2px solid #F1F1F1',
+    borderRadius: '4px',
+  },
+};
+
+PlaidLink.propTypes = {
+  // Displayed once a user has successfully linked their account
+  clientName: PropTypes.string.isRequired,
+
+  // The Plaid API environment on which to create user accounts.
+  // For development and testing, use tartan. For production, use production
+  env: PropTypes.oneOf(['tartan', 'sandbox', 'development', 'production']).isRequired,
+
+  // Open link to a specific institution, for a more custom solution
+  institution: PropTypes.string,
+
+  // The public_key associated with your account; available from
+  // the Plaid dashboard (https://dashboard.plaid.com)
+  publicKey: PropTypes.string.isRequired,
+
+  // The Plaid products you wish to use, an array containing some of connect,
+  // auth, identity, income, transactions
+  product: PropTypes.arrayOf(PropTypes.oneOf(['connect', 'auth', 'identity', 'income', 'transactions'])).isRequired,
+
+  // Specify an existing user's public token to launch Link in update mode.
+  // This will cause Link to open directly to the authentication step for
+  // that user's institution.
+  token: PropTypes.string,
+
+  // Set to true to launch Link with the 'Select Account' pane enabled.
+  // Allows users to select an individual account once they've authenticated
+  selectAccount: PropTypes.bool,
+
+  // Specify a webhook to associate with a user.
+  webhook: PropTypes.string,
+
+  // A function that is called when a user has successfully onboarded their
+  // account. The function should expect two arguments, the public_key and a
+  // metadata object
+  onSuccess: PropTypes.func.isRequired,
+
+  // A function that is called when a user has specifically exited Link flow
+  onExit: PropTypes.func,
+
+  // A function that is called when the Link module has finished loading.
+  // Calls to plaidLinkHandler.open() prior to the onLoad callback will be
+  // delayed until the module is fully loaded.
+  onLoad: PropTypes.func,
+
+  // Text to display in the button
+  buttonText: PropTypes.string,
+
+  // Button Styles as an Object
+  style: PropTypes.object,
+
+  // Button Class names as a String
+  className: PropTypes.string,
+
+  // ApiVersion flag to use new version of Plaid API
+  apiVersion: PropTypes.string
 };
 
 export default PlaidLink;

--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -1,26 +1,31 @@
-'use strict';
+const React = require('react')
+const PropTypes = require('prop-types')
+//import Script from 'react-load-script'
 
-const React = require('react');
-const PropTypes = require('prop-types');
-const ReactScriptLoaderMixin = require('react-script-loader').ReactScriptLoaderMixin;
-
-const PlaidLink = React.createClass({
-  mixins: [ReactScriptLoaderMixin],
-  getDefaultProps: function() {
-    return {
-      institution: null,
-      selectAccount: false,
-      buttonText: 'Open Link',
-      style: {
-        padding: '6px 4px',
-        outline: 'none',
-        background: '#FFFFFF',
-        border: '2px solid #F1F1F1',
-        borderRadius: '4px',
-      },
+class PlaidLink extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      disabledButton: true,
+      linkLoaded: false,
+      initializeURL: 'https://cdn.plaid.com/link/v2/stable/link-initialize.js'
     };
-  },
-  propTypes: {
+  };
+
+  PlaidLink.defaultProps = {
+    institution: null,
+    selectAccount: false,
+    buttonText: 'Open Link',
+    style: {
+      padding: '6px 4px',
+      outline: 'none',
+      background: '#FFFFFF',
+      border: '2px solid #F1F1F1',
+      borderRadius: '4px',
+    },
+  };
+
+  PlaidLink.propTypes = {
     // Displayed once a user has successfully linked their account
     clientName: PropTypes.string.isRequired,
 
@@ -35,7 +40,7 @@ const PlaidLink = React.createClass({
     // the Plaid dashboard (https://dashboard.plaid.com)
     publicKey: PropTypes.string.isRequired,
 
-    // The Plaid products you wish to use, an array containing some of connect, 
+    // The Plaid products you wish to use, an array containing some of connect,
     // auth, identity, income, transactions
     product: PropTypes.arrayOf(PropTypes.oneOf(['connect', 'auth', 'identity', 'income', 'transactions'])).isRequired,
 
@@ -74,22 +79,15 @@ const PlaidLink = React.createClass({
     className: PropTypes.string,
 
     // ApiVersion flag to use new version of Plaid API
-
     apiVersion: PropTypes.string
-  },
-  getInitialState: function() {
-    return {
-      disabledButton: true,
-      linkLoaded: false,
-    };
-  },
-  getScriptURL: function() {
-    return 'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
-  },
-  onScriptError: function() {
+  };
+
+
+  onScriptError = () => {
     console.error('There was an issue loading the link-initialize.js script');
-  },
-  onScriptLoaded: function() {
+  };
+
+  onScriptLoaded = () => {
     window.linkHandler = Plaid.create({
       clientName: this.props.clientName,
       env: this.props.env,
@@ -105,23 +103,27 @@ const PlaidLink = React.createClass({
     });
 
     this.setState({disabledButton: false});
-  },
-  handleLinkOnLoad: function() {
+  };
+
+  handleLinkOnLoad = () => {
     this.props.onLoad && this.props.onLoad();
     this.setState({linkLoaded: true});
-  },
-  handleOnClick: function() {
+  }
+
+  handleOnClick = () => {
     this.props.onClick && this.props.onClick();
     var institution = this.props.institution || null;
     if (window.linkHandler) {
       window.linkHandler.open(institution);
     }
-  },
-  exit: function exit(configurationObject) {
+  }
+
+  exit = configurationObject => {
     if (window.linkHandler) {
       window.linkHandler.exit(configurationObject);
     }
-  },
+  }
+
   render: function() {
     return (
       <button
@@ -134,6 +136,6 @@ const PlaidLink = React.createClass({
       </button>
     );
   }
-});
+};
 
-module.exports = PlaidLink;
+export default PlaidLink;

--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
-import Script from 'react-load-script';
-import PropTypes from 'prop-types';
+import React, { Component } from "react";
+import Script from "react-load-script";
+import PropTypes from "prop-types";
 
 class PlaidLink extends Component {
   constructor(props) {
@@ -8,21 +8,21 @@ class PlaidLink extends Component {
     this.state = {
       disabledButton: true,
       linkLoaded: false,
-      initializeURL: 'https://cdn.plaid.com/link/v2/stable/link-initialize.js'
+      initializeURL: "https://cdn.plaid.com/link/v2/stable/link-initialize.js"
     };
-  };
+  }
 
   static defaultProps = {
     institution: null,
     selectAccount: false,
-    buttonText: 'Open Link',
+    buttonText: "Open Link",
     style: {
-      padding: '6px 4px',
-      outline: 'none',
-      background: '#FFFFFF',
-      border: '2px solid #F1F1F1',
-      borderRadius: '4px',
-    },
+      padding: "6px 4px",
+      outline: "none",
+      background: "#FFFFFF",
+      border: "2px solid #F1F1F1",
+      borderRadius: "4px"
+    }
   };
 
   static propTypes = {
@@ -31,7 +31,8 @@ class PlaidLink extends Component {
 
     // The Plaid API environment on which to create user accounts.
     // For development and testing, use tartan. For production, use production
-    env: PropTypes.oneOf(['tartan', 'sandbox', 'development', 'production']).isRequired,
+    env: PropTypes.oneOf(["tartan", "sandbox", "development", "production"])
+      .isRequired,
 
     // Open link to a specific institution, for a more custom solution
     institution: PropTypes.string,
@@ -42,7 +43,9 @@ class PlaidLink extends Component {
 
     // The Plaid products you wish to use, an array containing some of connect,
     // auth, identity, income, transactions
-    product: PropTypes.arrayOf(PropTypes.oneOf(['connect', 'auth', 'identity', 'income', 'transactions'])).isRequired,
+    product: PropTypes.arrayOf(
+      PropTypes.oneOf(["connect", "auth", "identity", "income", "transactions"])
+    ).isRequired,
 
     // Specify an existing user's public token to launch Link in update mode.
     // This will cause Link to open directly to the authentication step for
@@ -83,7 +86,7 @@ class PlaidLink extends Component {
   };
 
   onScriptError = () => {
-    console.error('There was an issue loading the link-initialize.js script');
+    console.error("There was an issue loading the link-initialize.js script");
   };
 
   onScriptLoaded = () => {
@@ -98,16 +101,16 @@ class PlaidLink extends Component {
       product: this.props.product,
       selectAccount: this.props.selectAccount,
       token: this.props.token,
-      webhook: this.props.webhook,
+      webhook: this.props.webhook
     });
 
-    this.setState({disabledButton: false});
+    this.setState({ disabledButton: false });
   };
 
   handleLinkOnLoad = () => {
     this.props.onLoad && this.props.onLoad();
-    this.setState({linkLoaded: true});
-  }
+    this.setState({ linkLoaded: true });
+  };
 
   handleOnClick = () => {
     this.props.onClick && this.props.onClick();
@@ -115,13 +118,13 @@ class PlaidLink extends Component {
     if (window.linkHandler) {
       window.linkHandler.open(institution);
     }
-  }
+  };
 
   exit = configurationObject => {
     if (window.linkHandler) {
       window.linkHandler.exit(configurationObject);
     }
-  }
+  };
 
   render() {
     return (
@@ -130,18 +133,18 @@ class PlaidLink extends Component {
           onClick={this.handleOnClick}
           disabled={this.state.disabledButton}
           style={this.props.style}
-          className={this.props.className}>
+          className={this.props.className}
+        >
           <span>{this.props.buttonText}</span>
         </button>
         <Script
           url={this.state.initializeURL}
           onError={this.onScriptError}
-          onLoad={this.onScriptLoaded} />
+          onLoad={this.onScriptLoaded}
+        />
       </div>
     );
   }
-};
-
-
+}
 
 export default PlaidLink;

--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -1,6 +1,7 @@
+import { Component } from 'react'
+//import Script from "react-load-script";
 const React = require('react')
 const PropTypes = require('prop-types')
-//import Script from 'react-load-script'
 
 class PlaidLink extends Component {
   constructor(props) {
@@ -12,7 +13,7 @@ class PlaidLink extends Component {
     };
   };
 
-  PlaidLink.defaultProps = {
+  static defaultProps = {
     institution: null,
     selectAccount: false,
     buttonText: 'Open Link',
@@ -25,7 +26,7 @@ class PlaidLink extends Component {
     },
   };
 
-  PlaidLink.propTypes = {
+  static propTypes = {
     // Displayed once a user has successfully linked their account
     clientName: PropTypes.string.isRequired,
 

--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Script from "react-load-script";
+import Script from 'react-load-script';
 import PropTypes from 'prop-types';
 
 class PlaidLink extends Component {


### PR DESCRIPTION
- Utilizes `extends Component`
- Changes load script library
- Moves `link-initialize.js` URL into state
- Wraps return elements in a `<div>`

Passing `make test` and working in a sample app we made as well. Hope this is a valuable contribution!