### PR TITLE
Update product prop type to match Plaid API

### DIFF
--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -44,7 +44,7 @@ class PlaidLink extends Component {
     // The Plaid products you wish to use, an array containing some of connect,
     // auth, identity, income, transactions
     product: PropTypes.arrayOf(
-      PropTypes.oneOf(["connect", "auth", "identity", "income", "transactions"])
+      PropTypes.oneOf(["auth", "identity", "transactions"])
     ).isRequired,
 
     // Specify an existing user's public token to launch Link in update mode.


### PR DESCRIPTION
The current version doesn't support Plaid's most recent input type for `products`. Per [the documentation](https://plaid.com/docs/api/#integrating-with-link), the input for `products` is now an array containing one or more of the following values: `transactions`, `auth`, `identity`.

This just updates the propType `products` to reflect this.