### PR TITLE
allow assets as product type

### DIFF
--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -53,7 +53,7 @@ class PlaidLink extends Component {
     publicKey: PropTypes.string.isRequired,
 
     // The Plaid products you wish to use, an array containing some of connect,
-    // auth, identity, income, transactions
+    // auth, identity, income, transactions, assets
     product: PropTypes.arrayOf(
       PropTypes.oneOf([
         'connect',  // legacy product name
@@ -62,6 +62,7 @@ class PlaidLink extends Component {
         'identity',
         'income',
         'transactions',
+        'assets',
       ])
     ).isRequired,
 


### PR DESCRIPTION
allows `assets` product to be included in the `products` prop.

[From the docs](https://plaid.com/docs/#integrating-with-link), `assets` is now an allowed product.

Screenshot from docs:
![image](https://user-images.githubusercontent.com/5386810/47109433-1262cd80-d203-11e8-8ed2-225669064dcb.png)
