### PR TITLE
Pass the click event down to the onClick function

### DIFF
--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -132,9 +132,9 @@ class PlaidLink extends Component {
     this.setState({ linkLoaded: true });
   }
 
-  handleOnClick() {
+  handleOnClick(event) {
     if (this.props.onClick != null) {
-      this.props.onClick();
+      this.props.onClick(event);
     }
     const institution = this.props.institution || null;
     if (window.linkHandler) {


### PR DESCRIPTION
It's useful in cases where the PlaidLink is inside a form and we need to do something like:

```
<PlaidLink onClick={e => e.preventDefault()}>...
```